### PR TITLE
Better regex for matching className:methodName

### DIFF
--- a/SlimController/Slim.php
+++ b/SlimController/Slim.php
@@ -81,7 +81,7 @@ class Slim extends \Slim\Slim
         }
 
         // having <className>:<methodName>
-        if (preg_match('/^(.+):+(.+)$/', $className, $match)) {
+        if (preg_match('/^([a-zA-Z0-9\\\\_]+):([a-zA-Z0-9_]+)$/', $className, $match)) {
             $className = $match[1];
             $methodName = $match[2]. $methodNameSuffix;
         }


### PR DESCRIPTION
I found that if you have a typo like:

``` php
$app->addRoutes(array(
    '/'            => 'Home::index',
));
```

`\InvalidArgumentException` is never thrown, this fix solve it with a more specific regex.
