### PR TITLE
We have no Default suffix, so we will not assume twig is the default. An...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,12 +77,15 @@ Minimal bootstrap file for this example
 
     <?php
 
+    // define a working directory
+    define('APP_PATH', dirname(__DIR__)); // PHP v5.3+
+
     // load
-    require 'vendor/autoload.php';
+    require APP_PATH . '/vendor/autoload.php';
 
     // init app
-    $app = new \SlimController\Slim(array(
-        'templates.path'             => './templates',
+    $app = New \SlimController\Slim(array(
+        'templates.path'             => APP_PATH . '/templates',
         'controller.class_prefix'    => '\\MyApp\\Controller',
         'controller.method_suffix'   => 'Action',
         'controller.template_suffix' => 'php',

--- a/src/SlimController/SlimController.php
+++ b/src/SlimController/SlimController.php
@@ -58,9 +58,11 @@ abstract class SlimController
     private $paramsPost = null;
 
     /**
+     * Suffix was never specified and defaults to empty string 
+     * 
      * @var string
      */
-    protected $renderTemplateSuffix = null;
+    protected $renderTemplateSuffix = 'twig';
 
     /**
      * Constructor for TodoQueue\Controller\Login


### PR DESCRIPTION
... app path is required or ./templates will not render correctly.

This is a backdate branch based on ehime/slimcontroller@ce4078e2c1e4176422733b2ef35799622a92bdcf
