### PR TITLE
Better RESTful routing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -107,6 +107,28 @@ Minimal bootstrap file for this example
 
 ## Configuration
 
+### RESTful Routing
+
+You can define the http method that routes use by adding it to the beginning of the route and separating the http method and the path by a space (or any whitespace char(s) [space, tab, newline]).
+
+    $app->addRoutes(array(
+        '/'               => 'Home:index',
+        'get /posts'      => 'Posts:index',
+        'get /posts/:id'  => 'Posts:show',
+        'post /posts'     => 'Posts:create'
+    ));
+
+Leading spaces in routes are ignored and all spaces in between the http method and the route are ignored so that you can have sexy indenting like this:
+
+    $app->addRoutes(array(
+        '     /'           => 'Home:index',
+        'get  /posts'      => 'Posts:index',
+        'get  /posts/:id'  => 'Posts:show',
+        'post /posts'      => 'Posts:create'
+    ));
+
+If you don't specify an http method then that route will work with any http method.
+
 ### controller.class_prefix
 
 Optional class prefix for controller classes. Will be prepended to routes.
@@ -162,9 +184,8 @@ Defaults to `twig`. Will be appended to template name given in `render()` method
                 error_log("ADDITIONAL MIDDLWARE FOR SINGLE ROUTE");
             }
         ),
-        '/hello/:name' => array(
+        'post /hello/:name' => array(
             'Home:hello',
-            'post',
             function() {
                 error_log("THIS ROUTE IS ONLY POST");
             }

--- a/tests/SlimController/Tests/SlimTest.php
+++ b/tests/SlimController/Tests/SlimTest.php
@@ -37,11 +37,22 @@ class SlimTest extends TestCase
         $this->assertEquals(1, count($this->app->router()->getMatchedRoutes($this->req->getMethod(), $this->req->getResourceUri())));
     }
 
-    public function testAddRoutesInExtendedFormat()
+    public function testAddRoutesInRestFormat()
     {
         $this->setUrl('/bla');
         $this->app->addRoutes(array(
-            '/bla' => array('Controller:index', 'get')
+            'get /bla' => 'Controller:index'
+        ));
+        $this->assertEquals(1, count($this->app->router()->getMatchedRoutes($this->req->getMethod(), $this->req->getResourceUri())));
+    }
+
+    public function testAddRoutesInRestFormatWithMultipleWhiteSpaceChars()
+    {
+        $this->setUrl('/bla');
+        $this->app->addRoutes(array(
+            '   get
+
+     		/bla' => 'Controller:index'
         ));
         $this->assertEquals(1, count($this->app->router()->getMatchedRoutes($this->req->getMethod(), $this->req->getResourceUri())));
     }
@@ -124,7 +135,7 @@ class SlimTest extends TestCase
     {
         $this->setUrl('/bla');
         $this->app->addRoutes(array(
-            '/bla' => array('Controller:index', 'foo')
+            'foo /bla' => 'Controller:index'
         ));
     }
 


### PR DESCRIPTION
Changed how http methods are defined in the router.  Http methods are now defined like this:

```
$app->addRoutes(array(
    '/'               => 'Home:index',
    'get /posts'      => 'Posts:index',
    'get /posts/:id'  => 'Posts:show',
    'post /posts'     => array('Posts:create', function() { echo 'Middleware!'; }),
    ...
));
```
