### PR TITLE
Add pseudo-constructors to controller classes

### DIFF
--- a/src/SlimController/SlimController.php
+++ b/src/SlimController/SlimController.php
@@ -85,6 +85,9 @@ abstract class SlimController
         if ($app->config('controller.cleanup_params')) {
             $this->paramCleanup = true;
         }
+        if (method_exists($this, 'setUp')) {
+            $this->setUp();
+        }
     }
 
     /**


### PR DESCRIPTION
This allows you to add a `protected function setUp()` to your controller class, to call on initialisation.